### PR TITLE
two bugfixes from Etsy

### DIFF
--- a/GearmanManager.php
+++ b/GearmanManager.php
@@ -633,7 +633,7 @@ class GearmanManager {
         if(empty($this->functions)){
             $this->log("No workers found");
             posix_kill($this->parent_pid, SIGUSR1);
-            exit(1);
+            exit();
         }
 
         $this->validate_lib_workers();

--- a/pecl-manager.php
+++ b/pecl-manager.php
@@ -189,7 +189,7 @@ class GearmanPeclManager extends GearmanManager {
                (!class_exists($func) || !method_exists($func, "run"))){
                 $this->log("Function $func not found in ".$props["path"]);
                 posix_kill($this->parent_pid, SIGUSR2);
-                exit(1);
+                exit();
             }
         }
     }
@@ -199,3 +199,4 @@ class GearmanPeclManager extends GearmanManager {
 $mgr = new GearmanPeclManager();
 
 ?>
+


### PR DESCRIPTION
Hi there, I'm an engineer at Etsy and wanted to contribute a small patch for two issues we ran into with GearmanManager.

The first issue is due to a bug in the pecl-manager. In validate_lib_workers, the instance variable $this->pid is assumed to be the parent process pid, so the SIGUSR2 will fire to the parent. In fact, that pid is the pid of the child process, since it is overwritten in the caller function validate_workers, so the SIGUSR2 is fired back onto the child process itself, resulting in incorrect behavior. 

To fix this, an instance variable, parent_pid, was added to the base class and set appropriately upon the fork. Subsequent consumers of the parent's pid were updated to use this new instance variable.

Additionally, we were running into an issue where the helper child process would die unexpectedly during startup due to apc errors. However, since the parent process is waiting in a while() loop for the signal bit to be flipped, the parent process never got past this loop. I've added some logic that will check for a non-zero exit code of the child process to ensure the parent process finishes (and exits appropriately) if the child dies unexpectedly. 
