### PR TITLE
set the -l (log_file) config param in getopt

### DIFF
--- a/GearmanManager.php
+++ b/GearmanManager.php
@@ -356,12 +356,7 @@ abstract class GearmanManager {
         }
 
         if(isset($opts["l"])){
-            if($opts["l"] === 'syslog'){
-                $this->log_syslog = true;
-            } else {
-                $this->log_file = $opts["l"];
-                $this->open_log_file($this->log_file);
-            }
+            $this->config['log_file'] = $opts['l'];
         }
 
         if (isset($opts['a'])) {


### PR DESCRIPTION
I was trying to use the install/deb.sh script, which uses the -l flag but I kept getting errors as 

Notice: Undefined index: log_file in /home/qzio/src/GearmanManager/GearmanManager.php on line 472
Warning: chown(): No such file or directory in /home/qzio/src/GearmanManager/GearmanManager.php on line 472

this little fix worked for me (I think)

Let me know if I'm completely out in the blue on this one ;)
