### PR TITLE
require job files once

### DIFF
--- a/pecl-manager.php
+++ b/pecl-manager.php
@@ -202,7 +202,7 @@ class GearmanPeclManager extends GearmanManager {
     protected function validate_lib_workers() {
 
         foreach($this->functions as $func => $props){
-            @include $props["path"];
+            require_once $props["path"];
             $real_func = $this->prefix.$func;
             if(!function_exists($real_func) &&
                (!class_exists($real_func) || !method_exists($real_func, "run"))){


### PR DESCRIPTION
I have a stupid setup, where my jobs can't be autoloaded through an autoloader, So i need to require them through a bootstrap that's included in all jobs.

since the validate_job_workers include the file again, with @ and without _once gearman-manager blows up with an

Child exited with non-zero exit code 65280

error.

this commit uses require_once instead of @include which seems to fix the problem for me.

why is @include used everywhere instead of require_once?
I don't know gearman-manager enough to know the argument so please enlighten me :)
