### PR TITLE
Load objects fix

### DIFF
--- a/pecl-manager.php
+++ b/pecl-manager.php
@@ -105,26 +105,23 @@ class GearmanPeclManager extends GearmanManager {
             $func = $job_name;
         }
 
-        if(empty($objects[$job_name]) && !function_exists($func) && !class_exists($func)){
-
-            if(!isset($this->functions[$job_name])){
-                $this->log("Function $func is not a registered job name");
-                return;
+        if(!isset($this->functions[$job_name])){
+            $this->log("Function $func is not a registered job name");
+            return;
+        }
+        if (empty($objects[$job_name])) {
+            if (!function_exists($func) && !class_exists($func)){
+                @include $this->functions[$job_name]["path"];
             }
-
-            @include $this->functions[$job_name]["path"];
-
-            if(class_exists($func) && method_exists($func, "run")){
-
-                $this->log("Creating a $func object", GearmanManager::LOG_LEVEL_WORKER_INFO);
-                $objects[$job_name] = new $func();
-
-            } elseif(!function_exists($func)) {
-
-                $this->log("Function $func not found");
-                return;
+            if (!function_exists($func)){
+                if (class_exists($func) && method_exists($func, "run")){
+                    $this->log("Creating a $func object", GearmanManager::LOG_LEVEL_WORKER_INFO);
+                    $objects[$job_name] = new $func();
+                } else {
+                    $this->log("function $job_name could not be loaded");
+                    return;
+                }
             }
-
         }
 
         $this->log("($h) Starting Job: $job_name", GearmanManager::LOG_LEVEL_WORKER_INFO);
@@ -202,7 +199,7 @@ class GearmanPeclManager extends GearmanManager {
     protected function validate_lib_workers() {
 
         foreach($this->functions as $func => $props){
-            require_once $props["path"];
+            @include_once $props["path"];
             $real_func = $this->prefix.$func;
             if(!function_exists($real_func) &&
                (!class_exists($real_func) || !method_exists($real_func, "run"))){
@@ -217,6 +214,3 @@ class GearmanPeclManager extends GearmanManager {
 }
 
 $mgr = new GearmanPeclManager();
-
-?>
-


### PR DESCRIPTION
this fix works for me, Maybe I'm doing it wrong in the first place, but if I run 1 worker with multiple jobs, the objects didn't get loaded properly, only the first job for each worker.. and there was no error, the job was reported as successful even though it didn't run at all.

Please let me know if there is something wrong with this patch.
