### PR TITLE
Turn off autoload with class_exists()

### DIFF
--- a/pecl-manager.php
+++ b/pecl-manager.php
@@ -105,7 +105,7 @@ class GearmanPeclManager extends GearmanManager {
             $func = $job_name;
         }
 
-        if(empty($objects[$job_name]) && !function_exists($func) && !class_exists($func)){
+        if(empty($objects[$job_name]) && !function_exists($func) && !class_exists($func, false)){
 
             if(!isset($this->functions[$job_name])){
                 $this->log("Function $func is not a registered job name");


### PR DESCRIPTION
Since the worker code is being included and instantiated inside the body of the conditional, we don't want to autoload the class with class_exists().
