### PR TITLE
Added default port to default server in setup.

### DIFF
--- a/GearmanManager.php
+++ b/GearmanManager.php
@@ -543,7 +543,7 @@ abstract class GearmanManager {
                 $this->servers = $this->config['host'];
             }
         } else {
-            $this->servers = array("127.0.0.1");
+            $this->servers = array("127.0.0.1:4730");
         }
 
         if (!empty($this->config['include']) && $this->config['include'] != "*") {


### PR DESCRIPTION
Currently, if host isn't specified (especially when using with pear-manager) it'll default to 127.0.0.1 with no port.
When trying to startup gearman-manager it'll get stuck in a loop forever as it can't connect to 127.0.0.1::. The solution is to change the default to 127.0.0.1:4730.
This is more of a convenience fix for new users, if theres a default/fallback it may as well work if possible.
