### PR TITLE
Update GearmanManager.php

### DIFF
--- a/GearmanManager.php
+++ b/GearmanManager.php
@@ -875,7 +875,7 @@ abstract class GearmanManager {
 
         // build up the list of worker timeouts
         foreach ($worker_list as $worker_name) {
-            $timeouts[$worker] = ((isset($this->config['functions'][$worker_name]['timeout'])) ?
+            $timeouts[$worker_name] = ((isset($this->config['functions'][$worker_name]['timeout'])) ?
                                     (int) $this->config['functions'][$worker_name]['timeout'] : $default_timeout);
         }
 


### PR DESCRIPTION
PHP Warning:  Illegal offset type in /usr/local/share/gearman-manager/GearmanManager.php on line 878

Array was given as $worker instead of string here.

That was the cause when workers were (re)started without timeout setting.

```
6887 WORKER Been running too long, exiting
6887 WORKER Child exiting
6885 PROC   Child 6887 exited with error code of 0 (BL)
6885 PROC   Started child 6965 (BL)
6885 DEBUG  Registering signals for child
6965 DEBUG  Adjusted max run time to 255 seconds
6965 WORKER Adding server 54.217.x.x
6965 WORKER Adding job BL ; timeout: 
```
