### PR TITLE
Fixed variable name when building list of worker timeouts

### DIFF
--- a/src/GearmanManager/GearmanManager.php
+++ b/src/GearmanManager/GearmanManager.php
@@ -878,7 +878,7 @@ abstract class GearmanManager {
 
         // build up the list of worker timeouts
         foreach ($worker_list as $worker_name) {
-            $timeouts[$worker] = ((isset($this->config['functions'][$worker_name]['timeout'])) ?
+            $timeouts[$worker_name] = ((isset($this->config['functions'][$worker_name]['timeout'])) ?
                                     (int) $this->config['functions'][$worker_name]['timeout'] : $default_timeout);
         }
 


### PR DESCRIPTION
This PR fixes the:

> Warning: Illegal offset type in [...]/src/GearmanManager/GearmanManager.php on line 881

error in the code on the overhaul branch.

I believe this was just a typo in overhaul, as the code is correct on your master branch.
