### PR TITLE
Fixed bug specifying log file path as command line argument

### DIFF
--- a/src/GearmanManager/GearmanManager.php
+++ b/src/GearmanManager/GearmanManager.php
@@ -383,7 +383,7 @@ abstract class GearmanManager {
         }
 
         if(isset($opts["l"])){
-            $this->log_file = $opts["l"];
+            $this->config['log_file'] = $opts["l"];
         }
 
         if (isset($opts['a'])) {


### PR DESCRIPTION
This PR fixes a bug where the log file path was ignored when supplied as a command line argument (it only worked when specified in the config file).
