### PR TITLE
Log file specified via command line parameter did not work

### DIFF
--- a/GearmanManager.php
+++ b/GearmanManager.php
@@ -381,6 +381,7 @@ abstract class GearmanManager {
 
         if(isset($opts["l"])){
             $this->log_file = $opts["l"];
+            $this->open_log_file();
         }
 
         if (isset($opts['a'])) {
@@ -1046,9 +1047,9 @@ abstract class GearmanManager {
                 fclose($this->log_file_handle);
             }
 
-            $this->log_file_handle = @fopen($this->config['log_file'], "a");
+            $this->log_file_handle = @fopen($this->log_file, "a");
             if(!$this->log_file_handle){
-                $this->show_help("Could not open log file {$this->config['log_file']}");
+                $this->show_help("Could not open log file {$this->log_file}");
             }
         }
 


### PR DESCRIPTION
This pull request fixes an issue concerning logging. Specifying  a log file via command line parameter did not work because open_log_file() method was never called in that case. Additionally that method did access $this->config['log_file'] and not the generic $this->log_file.

So, before logging did only work when specified via config file. Now it works in both cases.

Cheers
Etienne
