### PR TITLE
Allow override of prefix in local config - pecl only

### DIFF
--- a/GearmanManager.php
+++ b/GearmanManager.php
@@ -681,6 +681,15 @@ abstract class GearmanManager {
                     $this->functions[$function]['path'] = $file;
 
                     /**
+                     * Override "global" prefix, if it exists in a subarea.
+                     * Need to use array_key_exists, because global prefix could
+                     * be overriden with empty
+                     */
+                    if(array_key_exists('prefix', $this->config['functions'][$function])) {
+                        $this->functions[$function]['prefix'] =  $this->config['functions'][$function]['prefix'];
+                    }
+
+                    /**
                      * Note about priority. This exploits an undocumented feature
                      * of the gearman daemon. This will only work as long as the
                      * current behavior of the daemon remains the same. It is not

--- a/pecl-manager.php
+++ b/pecl-manager.php
@@ -101,7 +101,12 @@ class GearmanPeclManager extends GearmanManager {
 
         $job_name = $job->functionName();
 
-        if($this->prefix){
+        /**
+         * Precedence from local prefix
+         */
+        if(isset($this->functions[$job_name]) && array_key_exists('prefix', $this->functions[$job_name])) {
+            $func = $this->functions[$job_name]['prefix'].$job_name;
+        } elseif($this->prefix) {
             $func = $this->prefix.$job_name;
         } else {
             $func = $job_name;
@@ -206,6 +211,9 @@ class GearmanPeclManager extends GearmanManager {
         foreach($this->functions as $func => $props){
             require_once $props["path"];
             $real_func = $this->prefix.$func;
+            if(array_key_exists('prefix', $props)) {
+                $real_func = $props['prefix'].$func;
+            }
             if(!function_exists($real_func) &&
                (!class_exists($real_func) || !method_exists($real_func, "run"))){
                 $this->log("Function $real_func not found in ".$props["path"]);


### PR DESCRIPTION
This commit allows to set a prefix for a specific function and even allow overriding the "base"-prefix.
Since I do not use the pear version, I did not port it.
