### PR TITLE
Remove declare ticks calls

### DIFF
--- a/GearmanPearManager.php
+++ b/GearmanPearManager.php
@@ -2,9 +2,6 @@
 /**
  * Implements the worker portions of the PEAR Net_Gearman library
  */
-
-declare(ticks = 1);
-
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'GearmanManager.php';
 
 class GearmanPearManager extends GearmanManager {

--- a/GearmanPeclManager.php
+++ b/GearmanPeclManager.php
@@ -8,8 +8,6 @@
  *
  */
 
-declare(ticks = 1);
-
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'GearmanManager.php';
 
 /**

--- a/pear-manager.php
+++ b/pear-manager.php
@@ -10,8 +10,6 @@
  *
  */
 
-declare(ticks = 1);
-
 /**
  * Uncomment and set to your prefix.
  */

--- a/pecl-manager.php
+++ b/pecl-manager.php
@@ -10,8 +10,6 @@
  *
  */
 
-declare(ticks = 1);
-
 require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'GearmanPeclManager.php';
 
 $mgr = new GearmanPeclManager();


### PR DESCRIPTION
We don't use register_tick_function anywhere, so they aren't needed.  This depends on the jpirkey-updates1 pull request (commit: c80afca2fe2bf1ba5c1b142562f445bd766404a4)
