### PR TITLE
Restore parsing of configuration file

### DIFF
--- a/GearmanManager.php
+++ b/GearmanManager.php
@@ -397,12 +397,17 @@ abstract class GearmanManager {
             $this->config = array_merge($this->config, $config);
         }
 
-        if(isset($opts["c"])){
+        if(isset($opts["c"])) {
             $this->config['file'] = $opts['c'];
         }
 
-        if (isset($this->config['file']) && ! file_exists($this->config['file'])) {
-            $this->show_help("Config file {$this->config['file']} not found.");
+        if (isset($this->config['file'])) {
+            if (file_exists($this->config['file'])) {
+                $this->parse_config($this->config['file']);
+            }
+            else {
+                $this->show_help("Config file {$this->config['file']} not found.");
+            }
         }
 
         /**


### PR DESCRIPTION
For some reason, parsing of configuration files seem to have been removed in https://github.com/brianlmoon/GearmanManager/commit/70718c71a16f085b7aa320123a15c9f3eb2dd400#diff-4ef92d5970f5612c2d2d8ea8c16a7df9L372. This should return that functionality by re-adding the parse_config function call.
