### PR TITLE
Fix: Add .gitignore, ignore vendor directory and composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock


### PR DESCRIPTION
This PR
- [x] adds a missing `.gitignore`, following 397bf5b

:information_desk_person: When I clone the project and run

```
$ composer install
```

I'm left with a dirty index.
