### PR TITLE
Fix: No need to require GearmanManager

### DIFF
--- a/src/GearmanManager/Bridge/GearmanPearManager.php
+++ b/src/GearmanManager/Bridge/GearmanPearManager.php
@@ -12,10 +12,6 @@ use \GearmanManager\GearmanManager;
  *
  */
 
-if (!class_exists("GearmanManager")) {
-    require dirname(__FILE__)."/../GearmanManager.php";
-}
-
 /**
  * Implements the worker portions of the PEAR Net_Gearman library
  */

--- a/src/GearmanManager/Bridge/GearmanPeclManager.php
+++ b/src/GearmanManager/Bridge/GearmanPeclManager.php
@@ -12,10 +12,6 @@ use \GearmanManager\GearmanManager;
  *
  */
 
-if (!class_exists("GearmanManager")) {
-    require dirname(__FILE__)."/../GearmanManager.php";
-}
-
 /**
  * Implements the worker portions of the pecl/gearman library
  */


### PR DESCRIPTION
This PR

* [x] removes `require` statements as we'd ideally autoload with Composer

Blocked by #121.