### PR TITLE
Fix › Updated class_exists check due to namespacing

### DIFF
--- a/src/Bridge/GearmanPearManager.php
+++ b/src/Bridge/GearmanPearManager.php
@@ -12,7 +12,7 @@ use \GearmanManager\GearmanManager;
  *
  */
 
-if (!class_exists("GearmanManager")) {
+if (!class_exists('\GearmanManager\GearmanManager')) {
     require __DIR__."/../GearmanManager.php";
 }
 

--- a/src/Bridge/GearmanPeclManager.php
+++ b/src/Bridge/GearmanPeclManager.php
@@ -12,7 +12,7 @@ use \GearmanManager\GearmanManager;
  *
  */
 
-if (!class_exists("GearmanManager")) {
+if (!class_exists('\GearmanManager\GearmanManager')) {
     require __DIR__."/../GearmanManager.php";
 }
 


### PR DESCRIPTION
When doing a `class_exists` check, the fully qualified class name is required. 