### PR TITLE
Adds ability to configure the shutdown timeout

### DIFF
--- a/etc/config-advanced.ini
+++ b/etc/config-advanced.ini
@@ -32,6 +32,9 @@ auto_update=1
 ; Timeout n seconds for all jobs before work is reissued to another worker
 timeout = 300
 
+; Timeout n seconds after which workers will be forcefully terminated
+graceful_shutdown_wait_time = 60
+
 ; Other configuration options
 ; auto_update - If non-zero, workers are restarted when worker code changes, defaults to on
 ; exclude - A list of workers in worker_dir to exclude

--- a/src/GearmanManager.php
+++ b/src/GearmanManager.php
@@ -1235,7 +1235,7 @@ abstract class GearmanManager {
     }
 
     /**
-     * The way this daemon implementation starts workers. 
+     * The way this daemon implementation starts workers.
      *
      * @param $worker_list
      * @param $timeouts

--- a/src/GearmanManager.php
+++ b/src/GearmanManager.php
@@ -316,7 +316,7 @@ abstract class GearmanManager {
             }
 
 
-            if ($this->stop_work && time() - $this->stop_time > 60) {
+            if ($this->stop_work && time() - $this->stop_time > $this->config["graceful_shutdown_wait_time"]) {
                 $this->log("Children have not exited, killing.", GearmanManager::LOG_LEVEL_PROC_INFO);
                 $this->stop_children(SIGKILL);
             } else {


### PR DESCRIPTION
Adds a configuration setting for setting the shutdown timer through a config (from 60s hardcoded to config setting), such that it can be adjusted in production environments where container deployments or tasks are not hard-interrupted during a deploy.